### PR TITLE
enable custom filter config

### DIFF
--- a/philter_lite/__init__.py
+++ b/philter_lite/__init__.py
@@ -2,7 +2,7 @@
 from importlib import metadata
 
 from philter_lite.coordinate_map import CoordinateMap
-from philter_lite.filters import Filter, filter_from_dict, load_filters
+from philter_lite.filters import Filter, load_filters
 from philter_lite.philter import detect_phi
 
 # Writers
@@ -12,7 +12,6 @@ from .i2b2 import transform_text_i2b2
 __all__ = [
     "CoordinateMap",
     "Filter",
-    "filter_from_dict",
     "load_filters",
     "detect_phi",
     "transform_text_asterisk",

--- a/philter_lite/filters/__init__.py
+++ b/philter_lite/filters/__init__.py
@@ -1,3 +1,7 @@
+"""
+Filters
+"""
+import importlib
 import os
 import re
 import warnings
@@ -145,7 +149,7 @@ class FilterBuilder:
             )
 
 
-def load_filters(filters, regex_db=None, regex_context_db=None, set_db=None) -> List[Filter]:
+def load_filters(filters=None, regex_db=None, regex_context_db=None, set_db=None) -> List[Filter]:
     """
     Load and return a list of Filter objects.
 
@@ -155,11 +159,13 @@ def load_filters(filters, regex_db=None, regex_context_db=None, set_db=None) -> 
 
     Parameters
     ----------
-    filters : str or list of dict
+    filters : str, PathLike, or list of dict, optional
         If a string, it is interpreted as a filepath to a file containing
         filter definitions and must be a toml file with a key of `filters`.
 
         If a list of dict, each dict defines a filter.
+
+        If None, load default config from philter_lite/configs/philter_delta.toml
 
     regex_db : dict, optional
         Contains configuration for RegexFilters.
@@ -183,12 +189,19 @@ def load_filters(filters, regex_db=None, regex_context_db=None, set_db=None) -> 
     ...     regex_db=load_conf_toml('mypackage.mymodule', 'regex.toml'),
     ... )
     """
-    if isinstance(filters, str):
-        if not os.path.exists(filters):
-            raise FileNotFoundError("Filepath does not exist", filters)
+    if filters is None:
+        filters = (importlib.resources
+            .files('philter_lite.configs')
+            .joinpath('philter_delta.toml')
+        )
 
+    if isinstance(filters, (str, os.PathLike)):
         with open(filters, "rt", encoding="utf-8") as fil_file:
-            filters = toml.loads(fil_file.read())["filters"]
+            filters = toml.loads(fil_file.read())
+
+    # the toml format has key "filters" the has a list of filters
+    if isinstance(filters, dict):
+        filters = filters["filters"]
 
     if not isinstance(filters, list):
         raise RuntimeError(f"Expected a list, found a {type(filters)}")

--- a/philter_lite/filters/filter_db.py
+++ b/philter_lite/filters/filter_db.py
@@ -3,21 +3,22 @@ from typing import Any, MutableMapping
 
 import toml
 
-from philter_lite import filters
+FILTERS_PATH = 'philter_lite.filters'
+
+
+def load_conf_toml(package, filename):
+    path = resources.files(package).joinpath(filename)
+    with open(path, 'rt') as f:
+        return toml.loads(f.read())
 
 
 def load_regex_db() -> MutableMapping[str, Any]:
-    return toml.loads(resources.read_text(filters, "regex.toml"))
+    return load_conf_toml(FILTERS_PATH, "regex.toml")
 
 
 def load_regex_context_db() -> MutableMapping[str, Any]:
-    return toml.loads(resources.read_text(filters, "regex_context.toml"))
+    return load_conf_toml(FILTERS_PATH, "regex_context.toml")
 
 
 def load_set_db() -> MutableMapping[str, Any]:
-    return toml.loads(resources.read_text(filters, "set.toml"))
-
-
-regex_db: MutableMapping[str, Any] = load_regex_db()
-regex_context_db: MutableMapping[str, Any] = load_regex_context_db()
-set_db: MutableMapping[str, Any] = load_set_db()
+    return load_conf_toml(FILTERS_PATH, "set.toml")

--- a/tests/test_philter.py
+++ b/tests/test_philter.py
@@ -4,7 +4,11 @@ from typing import Any, Dict
 import pytest
 
 import philter_lite
-from philter_lite import detect_phi, filter_from_dict, filters, load_filters
+from philter_lite import detect_phi, filters, load_filters
+
+
+# create instance of callable filter builder with default config
+filter_from_dict = filters.FilterBuilder()
 
 
 def test_filter_from_dict():

--- a/tests/test_philter.py
+++ b/tests/test_philter.py
@@ -98,16 +98,12 @@ def test_filter_from_dict_missing_phi_type():
     assert filter.phi_type == "OTHER"
 
 
-def test_filter_from_dict_missing_file():
+def test_filter_from_dict_missing_keyword():
     filter_dict = {
         "type": "regex",
-        "filepath": "filters/regex/addresses/non_existent.txt",
+        "keyword": "non_existent_keyword_asdf",
     }
 
-    # TODO: This test appears to be intended to test that a reference to a file that doesn't exist
-    #       causes an exception - but the excption raised has nothing to do with that file-path.
-    #       Instead, the complaint is about a missing value for the "keyword" key.
-    #       Should be investigated.
     with pytest.raises(Exception):  # noqa: B017
         filter_from_dict(filter_dict)
 
@@ -115,6 +111,11 @@ def test_filter_from_dict_missing_file():
 def test_default_config():
     filters = load_filters(os.path.join(os.path.dirname(philter_lite.__file__), "configs/philter_delta.toml"))
     assert len(filters) > 0
+
+
+def test_non_existent_config():
+    with pytest.raises(FileNotFoundError):
+        load_filters("/doesnt/exist/bonko.toml")
 
 
 def test_detect_phi():


### PR DESCRIPTION
Enable client code to specify custom filter configuration including custom regex, regex_context, and set DBs.

## Background

Philter configuration occurs in two stages. The primary configuration file specifies the filter set, referencing secondary configuration files for extra settings specific to each sub-type of filter, such as regular expressions for `RegexFilters`. Philter allows client code to specify a custom primary configuration file but doesn't provide a mechanism to modify the secondary configurations, for example, to add a new regular expression.

## Solution

This PR introduces parameters to the `load_filters` function, accepting custom arguments for `regex_db`, `regex_context_db`, and `set_db`. Under the hood, we replace the `filter_from_dict` function with a callable class **FilterBuilder**. FilterBuilder's constructor takes arguments for custom configuration which default to the standard configuration.

From the client's point of view, that looks something like:

```python
import philter_lite as philter
from philter_lite.filters.filter_db import load_conf_toml

custom_filters = philter.load_filters(
    load_conf_toml('mypackage.conf', 'philter.toml'),
    regex_db=load_conf_toml('mypackage.conf', 'regex.toml'),
)

text = """
Patient Name: John Doe
MRN: 12345676-XYZ

Personally identifying information such as john.doe@test.com or 206-987-6543 should be removed.
"""

include_map, exclude_map, data_tracker = philter.detect_phi(text, patterns=custom_filters)
deidentified_text = philter.transform_text_asterisk(text, include_map)
print(deidentified_text)
```

### Loading filters on demand rather than at module load time

Before this change, the db files were default parameters to `filter_from_dict` and were therefore loaded at the time of importing philter_lite. Now, they are loaded when `load_filters` is called giving client code the opportunity to pass in custom values.

### Consequences

Client code that invokes `load_filters` will work as before with no changes. The second-level function `filter_from_dict` should probably not be part of the public API but was previously exposed at the top level of the package, probably for the benefit of testing. Any code accessing that function will need a single-line change to instantiate the class **FilterBuilder**, as has been done in `test_philter`.

```python
# create instance of callable filter builder with default config
filter_from_dict = filters.FilterBuilder()
```